### PR TITLE
skip-prone? predicate option for wrap-exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ like so:
 All frames from namespaces prefixed with the names in the list will be marked as
 application frames.
 
+### How do I skip prone for certain requests?
+
+Pass a predicate function to `skip-prone?`. For example, to exclude
+Postman requests check for `postman-token` in the headers:
+
+```clj
+(-> app
+    (prone/wrap-exceptions {:skip-prone? (fn [req]
+                                           (contains? (:headers req) "postman-token"))}))
+```
+
 ## Known problems
 
 - Compile-time errors renders the original ring error page, since our middleware

--- a/test/prone/middleware_test.clj
+++ b/test/prone/middleware_test.clj
@@ -25,3 +25,17 @@
   (is (= 203 (:status ((wrap-exceptions (fn [req]
                                           (debug "I need help")
                                           {:status 200})) {})))))
+
+(deftest excludes-unwanted-clients
+  (are [status headers] (= status (:status
+                                   ((wrap-exceptions
+                                     (fn [req]
+                                       (debug "I need help")
+                                       {:status 200})
+                                     {:skip-prone? (fn [req]
+                                                     (contains? (:headers req) "postman-token"))})
+                                    {:headers headers})))
+       200 {"postman-token" "12345"
+            "other" "value"}
+       203 {"random" "string"}
+       203 {}))


### PR DESCRIPTION
I use various http clients to test apis (postman, httpie, emacs restclient) but they don't do well with prone's output. This allows you to pass in some header patterns that should be excluded from prone without having to deactivate the middleware. It also allows the handy pattern of using `(debug)` and viewing prone's html in the browser while using an http client to view the api response.

``` clj
(-> app
    (prone/wrap-exceptions {:excluded-headers {"user-agent" #"HTTPie/.*"}}))

(-> app
    (prone/wrap-exceptions {:excluded-headers ["user-agent" #"HTTPie/.*"
                                               "user-agent" "Emacs24"]}))
```
