### PR TITLE
Fix NPE when normalizing an exception that has no message

### DIFF
--- a/src/prone/stacks.clj
+++ b/src/prone/stacks.clj
@@ -85,7 +85,8 @@
     normalized))
 
 (defn- add-frame-from-message [ex]
-  (if-let [data (re-find #"\(([^(]+.clj):(\d+):\d+\)" (:message ex))]
+  (if-let [data (and (:message ex)
+                     (re-find #"\(([^(]+.clj):(\d+):\d+\)" (:message ex)))]
     (let [[_ path line] data]
       (if (io/resource path)
         (update-in ex [:frames]

--- a/test/prone/stacks_test.clj
+++ b/test/prone/stacks_test.clj
@@ -121,3 +121,11 @@
                                             e)))]
     (is (not= "foo"
               (-> normalized :frames first :package)))))
+
+(deftest handle-null-message-exception
+  (let [normalized (normalize-exception (try
+                                          (.foo nil)
+                                          (catch NullPointerException e
+                                            e)))]
+    (is (nil?
+         (-> normalized :message)))))


### PR DESCRIPTION
Hi,

This PR will fix a problem that prone can cause NPE when handling exceptions that have no message (e.g. NullPointerException).