### PR TITLE
Fix an error when serializing closed stream

### DIFF
--- a/src/prone/prep.clj
+++ b/src/prone/prep.clj
@@ -5,7 +5,7 @@
             [clojure.string :as str]
             [clojure.walk :as walk]
             [prone.code-trunc :as clj-code])
-  (:import [java.io InputStream File]))
+  (:import [java.io InputStream File IOException]))
 
 (def max-source-lines
   "Source code files longer than this will need to be truncated in order for the
@@ -55,7 +55,9 @@
                                     ::original-type "java.lang.Class"}
    (instance? clojure.lang.IRecord val) {::value (into {} val)
                                          ::original-type (.getName (type val))}
-   (instance? InputStream val) {::value (slurp val)
+   (instance? InputStream val) {::value (try
+                                          (slurp val)
+                                          (catch IOException _ nil))
                                 ::original-type (get-type val)}
    (map? val) val
    (vector? val) val

--- a/test/prone/prep_test.clj
+++ b/test/prone/prep_test.clj
@@ -40,6 +40,8 @@
                 :prone.prep/original-type "java.net.URL"}
           :body {:prone.prep/value "Hello"
                  :prone.prep/original-type "java.io.ByteArrayInputStream"}
+          :closed-stream {:prone.prep/value nil
+                          :prone.prep/original-type "java.io.BufferedInputStream"}
           :lazy '(2 3 4)
           :record {:prone.prep/value {:num-hands 1}
                    :prone.prep/original-type "prone.prep_test.DefLeppard"}}
@@ -47,6 +49,7 @@
                                                :age 37
                                                :url (java.net.URL. "http://example.com")
                                                :body (ByteArrayInputStream. (.getBytes "Hello"))
+                                               :closed-stream (doto (io/input-stream "http://example.com") .close)
                                                :lazy (map inc [1 2 3])
                                                :record (DefLeppard. 1)}} "")
              :request :session))))


### PR DESCRIPTION
Hi

This is a workaround for the problem that Prone tries to serialize a closed stream and get an IOException.
There may be more user-friendly substitute value (currently, nil).