### PR TITLE
Adding easy to remember url for the latest exception

### DIFF
--- a/src/prone/middleware.clj
+++ b/src/prone/middleware.clj
@@ -67,7 +67,7 @@
 
 (defn- store-page [page]
   (let [uri (str "/prone/" (.toString (java.util.UUID/randomUUID)))]
-    (swap! pages assoc uri page)
+    (swap! pages assoc uri page "/prone/latest" page)
     (assoc page :uri uri)))
 
 (defn- serve-page [page & [status]]


### PR DESCRIPTION
So there is no need to look at the headers to find the correct link and copy and paste it.