### PR TITLE
Fix #33: Add .cljc support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,4 +27,6 @@
                    :cljsbuild {:builds [{:source-paths ["src" "dev"]
                                          :compiler {:output-to "dev-resources/prone/generated/prone.js"
                                                     :output-dir "dev-resources/prone/generated/out"
-                                                    :optimizations :whitespace}}]}}})
+                                                    :optimizations :whitespace}}]}}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]
+                   :test-paths ["test" "test-1.7"]}})

--- a/src/prone/prep.clj
+++ b/src/prone/prep.clj
@@ -49,7 +49,8 @@
   include type information - since we already display that next to it."
   [val]
   (let [s (pr-str val)]
-    (if (.startsWith s "#<")
+    (if (or (.startsWith s "#<")
+            (.startsWith s "#object["))
       (.toString val)
       s)))
 

--- a/test-1.7/prone/stacks_test_cljc.cljc
+++ b/test-1.7/prone/stacks_test_cljc.cljc
@@ -1,0 +1,55 @@
+(ns prone.stacks-test-cljc
+  (:require [prone.stacks :refer :all]
+            [clojure.test :refer :all]))
+
+(defn- create-ex [msg]
+  (try
+    (throw (Exception. msg))
+    (catch Exception e
+      e)))
+
+(def ex (create-ex "Message for you, Sir!"))
+
+(def anon-fn-ex ((fn [] (create-ex "Message for you, Sir!"))))
+
+(def clj-frame (->> (.getStackTrace ex)
+                    (filter #(re-find #"^prone" (.getClassName %)))
+                    first))
+
+(def clj-anon-frame (->> (.getStackTrace anon-fn-ex)
+                         (filter #(re-find #"^prone" (.getClassName %)))
+                         second))
+
+(deftest check-assumptions-about-exception
+  (is (= "Message for you, Sir!" (.getMessage ex)))
+
+  (is (= "prone.stacks_test_cljc$create_ex" (.getClassName clj-frame)))
+  (is (= "invoke" (.getMethodName clj-frame)))
+  (is (= "stacks_test_cljc.cljc" (.getFileName clj-frame)))
+  (is (= 5 (.getLineNumber clj-frame))))
+
+(deftest normalize-frame-test
+  (is (= {:class-path-url "prone/stacks_test_cljc.cljc"
+          :loaded-from nil
+          :file-name "stacks_test_cljc.cljc"
+          :method-name "create-ex"
+          :line-number 5
+          :package "prone.stacks-test-cljc"
+          :lang :clj}
+         (normalize-frame clj-frame)))
+
+  (is (= "[fn]" (:method-name (normalize-frame clj-anon-frame)))))
+
+(deftest adding-frames-from-exception-message
+  (let [normalized (normalize-exception (try
+                                          (throw (Exception. "java.lang.RuntimeException: No such var: foo, compiling:(prone/stacks_test_cljc.cljc:105:145)"))
+                                          (catch Exception e
+                                            e)))]
+    (is (= {:lang :clj
+            :package "prone.stacks-test-cljc"
+            :method-name nil
+            :loaded-from nil
+            :class-path-url "prone/stacks_test_cljc.cljc"
+            :file-name "stacks_test_cljc.cljc"
+            :line-number 105}
+           (first (:frames normalized))))))

--- a/test/prone/stacks_test.clj
+++ b/test/prone/stacks_test.clj
@@ -2,6 +2,9 @@
   (:require [prone.stacks :refer :all]
             [clojure.test :refer :all]))
 
+(defn clj-version []
+  (str "clojure-" (clojure-version)))
+
 (defn- create-ex [msg]
   (try
     (throw (Exception. msg))
@@ -30,7 +33,7 @@
   (is (= "prone.stacks_test$create_ex" (.getClassName clj-frame)))
   (is (= "invoke" (.getMethodName clj-frame)))
   (is (= "stacks_test.clj" (.getFileName clj-frame)))
-  (is (= 5 (.getLineNumber clj-frame)))
+  (is (= 8 (.getLineNumber clj-frame)))
 
   (is (= "clojure.lang.Reflector" (.getClassName java-frame)))
   (is (= "invokeConstructor" (.getMethodName java-frame)))
@@ -42,13 +45,13 @@
           :loaded-from nil
           :file-name "stacks_test.clj"
           :method-name "create-ex"
-          :line-number 5
+          :line-number 8
           :package "prone.stacks-test"
           :lang :clj}
          (normalize-frame clj-frame)))
 
   (is (= {:class-path-url "clojure/lang/Reflector.java"
-          :loaded-from "clojure-1.5.1"
+          :loaded-from (clj-version)
           :file-name "Reflector.java"
           :method-name "invokeConstructor"
           :line-number 180
@@ -60,13 +63,13 @@
   (is (= "[fn]" (:method-name (normalize-frame clj-anon-frame)))))
 
 (deftest loaded-from-test
-  (is (= "clojure-1.5.1"
+  (is (= (clj-version)
          (->> (.getStackTrace ex)
               (filter #(re-find #"^clojure.lang" (.getClassName %)))
               first
               normalize-frame
               :loaded-from)))
-  (is (= "clojure-1.5.1"
+  (is (= (clj-version)
          (->> (.getStackTrace ex)
               (filter #(re-find #"^clojure.core" (.getClassName %)))
               first


### PR DESCRIPTION
Fix #33: Adding .cljc pattern to match clj file type and to generate the correct file name

Test case requires at least clojure 1.7.0 to run, so added an additional profile with 1.7 clojure and with the specific test case for it.
Fixed also minor issue with how clojure 1.7.0 and above prints objects now "#object["