### PR TITLE
adds column to the first frame from the clojure compile message

### DIFF
--- a/src/prone/stacks.clj
+++ b/src/prone/stacks.clj
@@ -91,8 +91,8 @@
 
 (defn- add-frame-from-message [ex]
   (if-let [data (and (:message ex)
-                     (re-find #"\(([^(]+.cljc?):(\d+):\d+\)" (:message ex)))]
-    (let [[_ path line] data]
+                     (re-find #"\(([^(]+.cljc?):(\d+):(\d+)\)" (:message ex)))]
+    (let [[_ path line column] data]
       (if (io/resource path)
         (update-in ex [:frames]
                    #(conj % {:lang :clj
@@ -101,7 +101,8 @@
                              :loaded-from nil
                              :class-path-url path
                              :file-name (re-find #"[^/]+.cljc?" path)
-                             :line-number (Integer. line)}))
+                             :line-number (Integer. line)
+                             :column (Integer. column)}))
         ex))
     ex))
 

--- a/src/prone/ui/components/source_location.cljs
+++ b/src/prone/ui/components/source_location.cljs
@@ -25,6 +25,8 @@
                                 (d/span {:className "filename"}
                                         (:file-name src-loc))
                                 ", line "
-                                (d/span {:className "line"} (:line-number src-loc)))
+                                (d/span {:className "line"} (:line-number src-loc))
+                                (when-let [column (:column src-loc)]
+                                  (str ", column " column)))
                          (d/div {:className "location"}
                                 "(unknown file)"))))))

--- a/test/prone/prep_test.clj
+++ b/test/prone/prep_test.clj
@@ -60,7 +60,7 @@
                                                :age 37
                                                :url (java.net.URL. "http://example.com")
                                                :body (ByteArrayInputStream. (.getBytes "Hello"))
-                                               :closed-stream (doto (io/input-stream "http://example.com") .close)
+                                               :closed-stream (doto (io/input-stream "http://google.com") .close)
                                                :lazy (map inc [1 2 3])
                                                :record (DefLeppard. 1)
                                                :datomic (let [db (d/db conn)]

--- a/test/prone/prep_test.clj
+++ b/test/prone/prep_test.clj
@@ -60,7 +60,7 @@
                                                :age 37
                                                :url (java.net.URL. "http://example.com")
                                                :body (ByteArrayInputStream. (.getBytes "Hello"))
-                                               :closed-stream (doto (io/input-stream "http://google.com") .close)
+                                               :closed-stream (doto (io/input-stream "http://example.com") .close)
                                                :lazy (map inc [1 2 3])
                                                :record (DefLeppard. 1)
                                                :datomic (let [db (d/db conn)]

--- a/test/prone/stacks_test.clj
+++ b/test/prone/stacks_test.clj
@@ -117,7 +117,8 @@
             :loaded-from nil
             :class-path-url "prone/stacks_test.clj"
             :file-name "stacks_test.clj"
-            :line-number 105}
+            :line-number 105
+            :column 145}
            (first (:frames normalized))))))
 
 (deftest don-t-add-frames-from-non-existent-files

--- a/test/prone/stacks_test_cljc.cljc
+++ b/test/prone/stacks_test_cljc.cljc
@@ -54,5 +54,6 @@
             :loaded-from nil
             :class-path-url "prone/stacks_test_cljc.cljc"
             :file-name "stacks_test_cljc.cljc"
-            :line-number 105}
+            :line-number 105
+            :column 145}
            (first (:frames normalized))))))


### PR DESCRIPTION
Shows the column as well as line number when present for the first frame.
It is useful for code highlighting with libraries other than PrismJS (such as codemirror)
which allow setting a cursor position.