### PR TITLE
Fail gracefully when there's no project.clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ After making changes to static files in `dev-resources`, run
 
 ## License: BSD
 
-Copyright © 2014-2015 Christian Johansen & Magnar Sveen. All rights reserved.
+Copyright © 2014-2018 Christian Johansen & Magnar Sveen. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/src/prone/middleware.clj
+++ b/src/prone/middleware.clj
@@ -20,7 +20,10 @@
   application name from project.clj - this allows prone to differentiate
   application frames from libraries/runtime frames."
   []
-  (find-application-name-in-project-clj (slurp "project.clj")))
+  (try
+    (find-application-name-in-project-clj (slurp "project.clj"))
+    (catch java.io.FileNotFoundException e
+      nil)))
 
 (defn- random-string-not-present-in
   "Look for a random string that is not present in haystack, increasing the
@@ -110,7 +113,10 @@
   (prep-error-page (normalize-exception e)
                    debug-data
                    request
-                   (or app-namespaces [(get-application-name)])))
+                   (or app-namespaces
+                       (when-let [app-name (get-application-name)]
+                         [app-name])
+                       [])))
 
 (defn exceptions-response
   "Ring Response for prone exceptions data."


### PR DESCRIPTION
Currently Prone assumes leiningen. This small change makes it not fall on its face when that's not the case.