### PR TITLE
minor typographical correction: 2020 -> 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pass to `debug`.
 
 ## Install
 
-Add `[prone "2020-04-23"]` to `:dependencies` in your `project.clj`.
+Add `[prone "2021-04-23"]` to `:dependencies` in your `project.clj`.
 
 This project no longer uses Semantic Versioning. Instead we're aiming to never
 break the API. Feel free to check out the [change log](#change-log).


### PR DESCRIPTION
The version listed in the README.md appears to be incorrect. Changed year to 2021.